### PR TITLE
Fixed warning about superfluous switch

### DIFF
--- a/src/classes/Platform.cpp
+++ b/src/classes/Platform.cpp
@@ -398,9 +398,9 @@ void Platform::handleOSEvents(Input* input)
       }
       case SDL_KEYDOWN:
       {
-        switch (event.key.keysym.sym)
+        //switch (event.key.keysym.sym)
         {
-          default:
+          //default:
           {
             int scanCode = event.key.keysym.scancode;
 


### PR DESCRIPTION
Fixed "warning C4065: switch statement contains 'default' but no 'case' labels" by commenting out lines 401 and 403 (same as 421 and 423).